### PR TITLE
ID間違え

### DIFF
--- a/seeds/enemy_rewards.csv
+++ b/seeds/enemy_rewards.csv
@@ -2,4 +2,4 @@ id,enemy_id,giftable_type,giftable_id,amount
 1,1,Coin,1,5000
 2,2,Coin,1,10000
 3,3,Star,1,3
-4,4,Dungeon,2,1
+4,4,Dungeon,1,1


### PR DESCRIPTION
「2をあける」つもりでID=2を付与してたけど、2がプレイできる条件は「1をクリアする」なので、報酬として付与すべきは2ではなく1
ややこしいことになっちゃった、でも1クリアがいい