### PR TITLE
謎の報酬量ミスを修正

### DIFF
--- a/seeds/achievement_step_rewards.csv
+++ b/seeds/achievement_step_rewards.csv
@@ -97,7 +97,7 @@ id,achievement_step_id,giftable_type,giftable_id,amount
 21407,21407,Star,1,35
 21408,21408,Star,1,40
 21501,21501,Star,1,5
-21502,21502,Star,1,50
+21502,21502,Star,1,10
 21503,21503,Star,1,15
 21504,21504,Star,1,20
 21505,21505,Star,1,25


### PR DESCRIPTION
なんで？